### PR TITLE
chore: exclude canary checker generated pods by default

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -3,5 +3,5 @@ name: mission-control-kubernetes
 description: A Helm chart for Kubernetes bundle for Flanksource Mission Control
 icon: https://github.com/flanksource/docs/blob/main/docs/images/flanksource-icon.png?raw=true
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "1.0.0"

--- a/charts/kubernetes/templates/scraper.yaml
+++ b/charts/kubernetes/templates/scraper.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
 spec:
+  schedule: {{ .Values.scraper.schedule | quote }}
   kubernetes:
     - clusterName: {{ .Values.clusterName }}
       exclusions:

--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -12,6 +12,7 @@ topology:
 
 scraper:
   name: kubernetes
+  schedule: "@every 5m"
   exclusions:
     name: []
     namespace: []

--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -20,7 +20,8 @@ scraper:
   defaultExclusions:
     name: []
     namespace: []
-    labels: {}
+    labels:
+       canary-checker.flanksource.com/generated: "true"
     kind:
       - Secret
       - APIService


### PR DESCRIPTION
Fixes: https://github.com/flanksource/mission-control-registry/issues/49

@moshloop How to filter events for the pods ? There is no data in change result that we can write CEL for, unless we can filter by config_id ...

```
----
id                  | c0fa7621-dcb2-40aa-b832-3ecdcefe403d
config_id           | a06cf776-e46c-4dc0-a7f4-63ab7a99aa97
external_change_id  | 247bfd97-064b-49b8-9dd2-4c16b4a39251
external_created_by | 
change_type         | Pulling
severity            | 
source              | kubernetes/component=kubelet,host=ip-10-0-6-132.eu-west-1.compute.internal
summary             | Pulling image "quay.io/toni0/hello-webserver-golang:latest"
patches             | 
diff                | 
details             | {"reason": "Pulling", "source": {"host": "ip-10-0-6-132.eu-west-1.compute.internal", "component": "kubelet"}, "message": "Pulling 
image \"quay.io/toni0/hello-webserver-golang:latest\"", "metadata": {"uid": "247bfd97-064b-49b8-9dd2-4c16b4a39251", "name": "hello-world-golang-1.17afd4
9a81fedc16", "namespace": "canaries", "resourceVersion": "179164550", "creationTimestamp": null}}
created_by          | 
created_at          | 0001-01-01 00:00:00+00
is_pushed           | f
-[ RECORD 2 ]-------+-----------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------------------
----
id                  | 186ee585-b663-488a-9398-e5f9017c928e
config_id           | a06cf776-e46c-4dc0-a7f4-63ab7a99aa97
external_change_id  | 55d921b9-5053-474d-b5f7-e1c1e15e1c88
external_created_by | 
change_type         | Killing
severity            | 
source              | kubernetes/component=kubelet,host=ip-10-0-6-132.eu-west-1.compute.internal
summary             | Stopping container hello
patches             | 
diff                | 
details             | {"reason": "Killing", "source": {"host": "ip-10-0-6-132.eu-west-1.compute.internal", "component": "kubelet"}, "message": "Stopping
 container hello", "metadata": {"uid": "55d921b9-5053-474d-b5f7-e1c1e15e1c88", "name": "hello-world-golang-1.17afd49ccba5cd59", "namespace": "canaries",
 "resourceVersion": "179164627", "creationTimestamp": null}}
created_by          | 
created_at          | 0001-01-01 00:00:00+00
is_pushed           | f
```