### PR TITLE
fix: bad cel expr for k8s endpoints

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -3,5 +3,5 @@ name: mission-control-kubernetes
 description: A Helm chart for Kubernetes bundle for Flanksource Mission Control
 icon: https://github.com/flanksource/docs/blob/main/docs/images/flanksource-icon.png?raw=true
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.0.0"

--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -87,7 +87,7 @@ scraper:
     changes:
       exclude:
         - 'config_type == "Kubernetes::Application" && details.message == "status.reconciledAt" && change_type == "diff" && details.involvedObject.apiVersion == "argoproj.io/v1alpha1"'
-        - 'config_type == "Kubernetes::Endpoints" && details.message == "metadata.annotations.endpoints.kubernetes.io/last-change-trigger-time"'
+        - 'config_type == "Kubernetes::Endpoints" && has(details.message) && details.message == "metadata.annotations.endpoints.kubernetes.io/last-change-trigger-time"'
         - 'config_type == "Kubernetes::Node" && details.message == "status.images"'
         - 'details.source.component == "canary-checker" && (change_type == "Failed" || change_type == "Pass")'
 


### PR DESCRIPTION
```
2024-02-26T11:51:55.637	ERROR	failed to run scraper b8e78065-c9e4-40c8-bcf0-de3a39423092: failed to save results: failed to update db: [Endpoints/01884897-0e2e-abd3-3e83-26ecc442abc9] failed to save 1 changes: failed to evaluate change exclusion expression(config_type == "Kubernetes::Endpoints" && details.message == "metadata.annotations.endpoints.kubernetes.io/last-change-trigger-time"): error evaluating expression config_type == "Kubernetes::Endpoints" && details.message == "metadata.annotations.endpoints.kubernetes.io/last-change-trigger-time": no such key: message: no such key: message
```

@adityathebe This was breaking on prod, FYI