### PR TITLE
fix: HelmRelease component relationship with the CRD config

### DIFF
--- a/topologies/flux/flux.yaml
+++ b/topologies/flux/flux.yaml
@@ -40,7 +40,10 @@ spec:
                       configs: [
                         {
                           name: r.name,
-                          type: "HelmRelease",
+                          type: "Kubernetes::HelmRelease",
+                          tags: {
+                            "namespace": r.namespace,
+                          }
                         }
                       ],
                       properties: [


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control-registry/issues/63