### PR TITLE
fix: relationship mapping pod->pvc

### DIFF
--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -124,7 +124,7 @@ scraper:
           expr: |
             has(config.spec.selector) && has(config.spec.selector.name) ? config.spec.selector.name : ''
       # Link Pods to PVCs
-      - filter: config_type == 'Kubernetes::Pod'
+      - filter: config_type == 'Kubernetes::Pod' && has(config.spec) && has(config.spec.volumes)
         expr: |
           config.spec.volumes.
             filter(item, has(item.persistentVolumeClaim)).


### PR DESCRIPTION
handles cases where the pod spec doesn't have volumes

resolves: https://github.com/flanksource/mission-control-registry/issues/147