### PR TITLE
chore: use pod and node metrics if prometheus url is empty

### DIFF
--- a/charts/kubernetes/templates/_helpers.tpl
+++ b/charts/kubernetes/templates/_helpers.tpl
@@ -63,3 +63,209 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Metrics
+*/}}
+{{- define "kubernetes.topology.metricProperties.prometheus.cluster" -}}
+- name: cpu
+  lookup:
+    prometheus:
+    - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          [{'name': 'cpu', 'value': int(results[0].value), 'headline': true, 'unit': 'millicores'}].toJSON()
+- name: memory
+  lookup:
+    prometheus:
+    - query: 'sum(container_memory_working_set_bytes{container!=""})'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          [{'name': 'memory', 'value': int(results[0].value), 'headline': true, 'unit': 'bytes'}].toJSON()
+{{- end }}
+
+
+
+{{- define "kubernetes.topology.metricProperties.prometheus.node" -}}
+- name: cpu
+  lookup:
+    prometheus:
+    - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (node)'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          dyn(results).map(r, {
+            'name': r.node,
+            'properties': [{'name': 'cpu', 'value': math.Ceil(int(r.value))}]
+          }).toJSON()
+- name: memory
+  lookup:
+    prometheus:
+    - query: 'sum(container_memory_working_set_bytes{container!="",pod!=""} * on(pod, namespace) group_left kube_pod_status_phase{phase="Running"} > 0) by (node)'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          dyn(results).map(r, {
+            'name': r.node,
+            'properties': [{'name': 'memory', 'value': int(r.value)}]
+          }).toJSON()
+
+- name: ephemeral-storage
+  lookup:
+    prometheus:
+    - query: 'max by (instance) (avg_over_time(node_filesystem_avail_bytes{mountpoint="/",fstype!="rootfs"}[5m]))'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          dyn(results).map(r, {
+            'name': r.instance,
+            'properties': [{'name': 'memory', 'value': int(r.value)}]
+          }).toJSON()
+{{- end }}
+
+
+{{- define "kubernetes.topology.metricProperties.prometheus.pod" -}}
+- name: cpu
+  lookup:
+    prometheus:
+    - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (pod)'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          dyn(results).map(r, {
+            'name': r.pod,
+            'properties': [{'name': 'cpu', 'value': math.Ceil(int(r.value))}]
+          }).toJSON()
+- name: memory
+  lookup:
+    prometheus:
+    - query: 'sum(container_memory_working_set_bytes{container!=""}) by (pod)'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          dyn(results).map(r, {
+            'name': r.pod,
+            'properties': [{'name': 'memory', 'value': int(r.value)}]
+            }).toJSON()
+{{- end }}
+
+
+{{- define "kubernetes.topology.metricProperties.prometheus.namespace" -}}
+- name: cpu
+  lookup:
+    prometheus:
+    - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (namespace)'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          dyn(results).map(r, {
+            'name': r.namespace,
+            'properties': [{'name': 'cpu', 'value': math.Ceil(int(r.value))}]
+          }).toJSON()
+- name: memory
+  lookup:
+    prometheus:
+    - query: 'sum(container_memory_working_set_bytes{container!="",pod!=""} * on(pod, namespace) group_left kube_pod_status_phase{phase="Running"} > 0) by (namespace)'
+      url: {{ .Values.prometheusURL | quote }}
+      display:
+        expr: |
+          dyn(results).map(r, {
+            'name': r.namespace,
+            'properties': [{'name': 'memory', 'value': int(r.value)}]
+          }).toJSON()
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.k8sMetrics.cluster" -}}
+- name: cluster-metrics
+  lookup:
+    kubernetes:
+    - kind: PodMetrics
+      display:
+        expr: |
+          [
+            {'name': 'cpu', 'headline': true, 'unit': 'millicores', 'value': math.Add(dyn(results).map(r, r.Object).map(r, math.Add(r.containers.map(c, k8s.cpuAsMillicores(c.usage.cpu)))))},
+            {'name': 'memory', 'headline': true, 'unit': 'bytes', 'value': math.Add(dyn(results).map(r, r.Object).map(r, math.Add(r.containers.map(c, k8s.memoryAsBytes(c.usage.memory)))))},
+          ].toJSON()
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.k8sMetrics.node" -}}
+- name: node-metrics
+  lookup:
+    kubernetes:
+      - kind: NodeMetrics
+        display:
+          expr: |
+            dyn(results).map(r, r.Object).map(r, {
+              'name': r.metadata.name,
+              'properties': [
+                {'name': 'cpu', 'value': k8s.cpuAsMillicores(r.usage.cpu)},
+                {'name': 'memory', 'value': k8s.memoryAsBytes(r.usage.memory)},
+              ]}).toJSON()
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.k8sMetrics.pod" -}}
+- name: pod-metrics
+  lookup:
+    kubernetes:
+      - kind: PodMetrics
+        display:
+          expr: |
+            dyn(results).map(r, r.Object).map(r, {
+              'name': r.metadata.name,
+              'properties': [
+                {'name': 'cpu', 'value': math.Add(r.containers.map(c, k8s.cpuAsMillicores(c.usage.cpu)))},
+                {'name': 'memory', 'value': math.Add(r.containers.map(c, k8s.memoryAsBytes(c.usage.memory)))},
+              ]}).toJSON()
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.k8sMetrics.namespace" -}}
+- name: namespace-metrics
+  lookup:
+    kubernetes:
+      - kind: PodMetrics
+        namespaceSelector:
+          name: '$(.component.name)'
+        test:
+          # To avoid no resources found error for empty namespaces
+          expr: 'true'
+        display:
+          expr: |
+            [
+              {'name': 'cpu', 'unit': 'millicores', 'headline': true, 'value': math.Add(dyn(results).map(r, r.Object).map(r, math.Add(r.containers.map(c, k8s.cpuAsMillicores(c.usage.cpu)))))},
+              {'name': 'memory', 'unit': 'bytes', 'headline': true, 'value': math.Add(dyn(results).map(r, r.Object).map(r, math.Add(r.containers.map(c, k8s.memoryAsBytes(c.usage.memory)))))},
+            ].toJSON()
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.cluster" -}}
+{{- if .Values.prometheusURL }}
+{{- include "kubernetes.topology.metricProperties.prometheus.cluster" . }}
+{{- else }}
+{{- include "kubernetes.topology.metricProperties.k8sMetrics.cluster" . }}
+{{- end }}
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.node" -}}
+{{- if .Values.prometheusURL }}
+{{- include "kubernetes.topology.metricProperties.prometheus.node" . }}
+{{- else }}
+{{- include "kubernetes.topology.metricProperties.k8sMetrics.node" . }}
+{{- end }}
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.pod" -}}
+{{- if .Values.prometheusURL }}
+{{- include "kubernetes.topology.metricProperties.prometheus.pod" . }}
+{{- else }}
+{{- include "kubernetes.topology.metricProperties.k8sMetrics.pod" . }}
+{{- end }}
+{{- end }}
+
+{{- define "kubernetes.topology.metricProperties.namespace" -}}
+{{- if .Values.prometheusURL }}
+{{- include "kubernetes.topology.metricProperties.prometheus.namespace" . }}
+{{- else }}
+{{- include "kubernetes.topology.metricProperties.k8sMetrics.namespace" . }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes/templates/topology.yaml
+++ b/charts/kubernetes/templates/topology.yaml
@@ -9,23 +9,7 @@ spec:
   icon: "{{ .Values.topology.icon }}"
   schedule: "{{ .Values.topology.schedule }}"
   properties:
-  - name: cpu
-    lookup:
-      prometheus:
-      - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))'
-        url: {{ .Values.prometheusURL | quote }}
-        display:
-          expr: |
-            [{'name': 'cpu', 'value': int(results[0].value), 'headline': true, 'unit': 'millicores'}].toJSON()
-  - name: memory
-    lookup:
-      prometheus:
-      - query: 'sum(container_memory_working_set_bytes{container!=""})'
-        url: {{ .Values.prometheusURL | quote }}
-        display:
-          expr: |
-            [{'name': 'memory', 'value': int(results[0].value), 'headline': true, 'unit': 'bytes'}].toJSON()
-
+    {{- include "kubernetes.topology.metricProperties.cluster" . | nindent 4 }}
   components:
     - name: nodes
       icon: server
@@ -33,71 +17,38 @@ spec:
         javascript: properties.zone + "/" + self.name
       type: Kubernetes::Node
       components:
-        - name: NodesGroup
-          type: virtual
-          icon: server
-          lookup:
-            kubernetes:
-              - kind: Node
-                name: k8s
-                {{- with .Values.kubeconfig }}
-                kubeconfig: {{ toYaml . | nindent 18}}
-                {{- end}}
-                display:
-                  expr: |
-                    dyn(results).map(r, r.Object).map(r, {
-                      'name': r.metadata.name,
-                      'type': 'Kubernetes::Node',
-                      'labels': k8s.labels(r),
-                      'external_id': r.metadata.name,
-                      'logs': [{'name': 'Kubernetes', 'type': 'KubernetesNode'}],
-                      'configs': [{'name': r.metadata.name, 'type': 'Kubernetes::Node'}],
-                      'selectors':[{'fieldSelector': 'node='+r.metadata.name}],
-                      'status': k8s.getHealth(r).health,
-                      'status_reason': k8s.getHealth(r).status + ' ' + k8s.getHealth(r).message,
-                      'properties': [
-                        {"name": "cpu", "max": k8s.cpuAsMillicores(r.status.allocatable["cpu"]), "unit": "millicores", "headline": true},
-                        {"name": "memory", "max": k8s.memoryAsBytes(r.status.allocatable["memory"]), "unit": "bytes", "headline": true},
-                        {"name": "ephemeral-storage", "max": k8s.memoryAsBytes(r.status.allocatable["ephemeral-storage"]), "unit": "bytes", "headline": true},
-                        {"name": "zone", "text": "topology.kubernetes.io/zone" in r.metadata.labels ? r.metadata.labels["topology.kubernetes.io/zone"]: ""},
-                      ]
-                    }).toJSON()
+      - name: NodesGroup
+        type: virtual
+        icon: server
+        lookup:
+          kubernetes:
+            - kind: Node
+              name: k8s
+              {{- with .Values.kubeconfig }}
+              kubeconfig: {{ toYaml . | nindent 18}}
+              {{- end}}
+              display:
+                expr: |
+                  dyn(results).map(r, r.Object).map(r, {
+                    'name': r.metadata.name,
+                    'type': 'Kubernetes::Node',
+                    'labels': k8s.labels(r),
+                    'external_id': r.metadata.name,
+                    'logs': [{'name': 'Kubernetes', 'type': 'KubernetesNode'}],
+                    'configs': [{'name': r.metadata.name, 'type': 'Kubernetes::Node'}],
+                    'selectors':[{'fieldSelector': 'node='+r.metadata.name}],
+                    'status': k8s.getHealth(r).health,
+                    'status_reason': k8s.getHealth(r).status + ' ' + k8s.getHealth(r).message,
+                    'properties': [
+                      {"name": "cpu", "max": k8s.cpuAsMillicores(r.status.allocatable["cpu"]), "unit": "millicores", "headline": true},
+                      {"name": "memory", "max": k8s.memoryAsBytes(r.status.allocatable["memory"]), "unit": "bytes", "headline": true},
+                      {"name": "ephemeral-storage", "max": k8s.memoryAsBytes(r.status.allocatable["ephemeral-storage"]), "unit": "bytes", "headline": true},
+                      {"name": "zone", "text": "topology.kubernetes.io/zone" in r.metadata.labels ? r.metadata.labels["topology.kubernetes.io/zone"]: ""},
+                    ]
+                  }).toJSON()
 
-          properties:
-            - name: cpu
-              lookup:
-                prometheus:
-                - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (node)'
-                  url: {{ .Values.prometheusURL | quote }}
-                  display:
-                    expr: |
-                      dyn(results).map(r, {
-                        'name': r.node,
-                        'properties': [{'name': 'cpu', 'value': math.Ceil(int(r.value))}]
-                      }).toJSON()
-            - name: memory
-              lookup:
-                prometheus:
-                - query: 'sum(container_memory_working_set_bytes{container!="",pod!=""} * on(pod, namespace) group_left kube_pod_status_phase{phase="Running"} > 0) by (node)'
-                  url: {{ .Values.prometheusURL | quote }}
-                  display:
-                    expr: |
-                      dyn(results).map(r, {
-                        'name': r.node,
-                        'properties': [{'name': 'memory', 'value': int(r.value)}]
-                      }).toJSON()
-
-            - name: ephemeral-storage
-              lookup:
-                prometheus:
-                - query: 'max by (instance) (avg_over_time(node_filesystem_avail_bytes{mountpoint="/",fstype!="rootfs"}[5m]))'
-                  url: {{ .Values.prometheusURL | quote }}
-                  display:
-                    expr: |
-                      dyn(results).map(r, {
-                        'name': r.instance,
-                        'properties': [{'name': 'memory', 'value': int(r.value)}]
-                      }).toJSON()
+        properties:
+          {{- include "kubernetes.topology.metricProperties.node" . | nindent 8 }}
 
     - name: PodGroup
       icon: pods
@@ -136,74 +87,32 @@ spec:
                 }).toJSON()
 
       properties:
-        - name: cpu
-          lookup:
-            prometheus:
-            - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (pod)'
-              url: {{ .Values.prometheusURL | quote }}
-              display:
-                expr: |
-                  dyn(results).map(r, {
-                    'name': r.pod,
-                    'properties': [{'name': 'cpu', 'value': math.Ceil(int(r.value))}]
-                  }).toJSON()
-        - name: memory
-          lookup:
-            prometheus:
-            - query: 'sum(container_memory_working_set_bytes{container!=""}) by (pod)'
-              url: {{ .Values.prometheusURL | quote }}
-              display:
-                expr: |
-                  dyn(results).map(r, {
-                    'name': r.pod,
-                    'properties': [{'name': 'memory', 'value': int(r.value)}]
-                    }).toJSON()
+        {{- include "kubernetes.topology.metricProperties.pod" . | nindent 6 }}
 
     - name: Namespaces
       icon: namespace
       type: Kubernetes::Namespaces
       components:
-        - name: NamespaceGroup
-          type: virtual
-          lookup:
-            kubernetes:
-              - kind: Namespace
-                {{- if not (empty .Values.topology.kubeconfig)}}
-                kubeconfig: {{ .Values.topology.kubeconfig | toYaml | nindent 18}}
-                {{- end}}
-                display:
-                  expr: |
-                    dyn(results).map(r, r.Object).map(r, {
-                      'name': r.metadata.name,
-                      'type': 'Kubernetes::Namespace',
-                      'external_id': r.metadata.name,
-                      'labels': k8s.labels(r),
-                      'configs': [{'name': r.metadata.name, 'type': 'Kubernetes::Namespace'}],
-                      'properties': [
-                        {'name': 'cpu', 'unit': 'millicores', 'headline': true},
-                        {'name': 'memory', 'unit': 'bytes', 'headline': true},
-                      ],
-                    }).toJSON()
-          properties:
-            - name: cpu
-              lookup:
-                prometheus:
-                - query: '1000 * sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (namespace)'
-                  url: {{ .Values.prometheusURL | quote }}
-                  display:
-                    expr: |
-                      dyn(results).map(r, {
-                        'name': r.namespace,
-                        'properties': [{'name': 'cpu', 'value': math.Ceil(int(r.value))}]
-                      }).toJSON()
-            - name: memory
-              lookup:
-                prometheus:
-                - query: 'sum(container_memory_working_set_bytes{container!="",pod!=""} * on(pod, namespace) group_left kube_pod_status_phase{phase="Running"} > 0) by (namespace)'
-                  url: {{ .Values.prometheusURL | quote }}
-                  display:
-                    expr: |
-                      dyn(results).map(r, {
-                        'name': r.namespace,
-                        'properties': [{'name': 'memory', 'value': int(r.value)}]
-                      }).toJSON()
+      - name: NamespaceGroup
+        type: virtual
+        lookup:
+          kubernetes:
+            - kind: Namespace
+              {{- if not (empty .Values.topology.kubeconfig)}}
+              kubeconfig: {{ .Values.topology.kubeconfig | toYaml | nindent 18}}
+              {{- end}}
+              display:
+                expr: |
+                  dyn(results).map(r, r.Object).map(r, {
+                    'name': r.metadata.name,
+                    'type': 'Kubernetes::Namespace',
+                    'external_id': r.metadata.name,
+                    'labels': k8s.labels(r),
+                    'configs': [{'name': r.metadata.name, 'type': 'Kubernetes::Namespace'}],
+                    'properties': [
+                      {'name': 'cpu', 'unit': 'millicores', 'headline': true},
+                      {'name': 'memory', 'unit': 'bytes', 'headline': true},
+                    ],
+                  }).toJSON()
+        properties:
+          {{- include "kubernetes.topology.metricProperties.namespace" . | nindent 8 }}


### PR DESCRIPTION
Fixes: https://github.com/flanksource/mission-control-registry/issues/176