### PR TITLE
fix: database reference for mission control topology

### DIFF
--- a/charts/mission-control/templates/mission-control.yaml
+++ b/charts/mission-control/templates/mission-control.yaml
@@ -6,10 +6,16 @@ metadata:
 spec:
   postgres:
     database:
-      value: mission-control
+      valueFrom:
+        secretKeyRef:
+          name: incident-commander-postgres
+          key: DATABASE
     insecureTLS: true
     host:
-      value: postgres
+      valueFrom:
+        secretKeyRef:
+          name: incident-commander-postgres
+          key: POSTGRES_HOST
     username:
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
Incorrect database name

![image](https://github.com/flanksource/mission-control-registry/assets/5863972/92e2fc54-33e9-44a7-9f4a-e8814a960c70)
