### PR TITLE
chore: add metrics.enabled flag in prometheus

### DIFF
--- a/charts/kubernetes/templates/_helpers.tpl
+++ b/charts/kubernetes/templates/_helpers.tpl
@@ -241,7 +241,7 @@ Metrics
 {{- define "kubernetes.topology.metricProperties.cluster" -}}
 {{- if .Values.prometheusURL }}
 {{- include "kubernetes.topology.metricProperties.prometheus.cluster" . }}
-{{- else }}
+{{- else if .Values.metrics.enabled }}
 {{- include "kubernetes.topology.metricProperties.k8sMetrics.cluster" . }}
 {{- end }}
 {{- end }}
@@ -249,7 +249,7 @@ Metrics
 {{- define "kubernetes.topology.metricProperties.node" -}}
 {{- if .Values.prometheusURL }}
 {{- include "kubernetes.topology.metricProperties.prometheus.node" . }}
-{{- else }}
+{{- else if .Values.metrics.enabled }}
 {{- include "kubernetes.topology.metricProperties.k8sMetrics.node" . }}
 {{- end }}
 {{- end }}
@@ -257,7 +257,7 @@ Metrics
 {{- define "kubernetes.topology.metricProperties.pod" -}}
 {{- if .Values.prometheusURL }}
 {{- include "kubernetes.topology.metricProperties.prometheus.pod" . }}
-{{- else }}
+{{- else if .Values.metrics.enabled }}
 {{- include "kubernetes.topology.metricProperties.k8sMetrics.pod" . }}
 {{- end }}
 {{- end }}
@@ -265,7 +265,7 @@ Metrics
 {{- define "kubernetes.topology.metricProperties.namespace" -}}
 {{- if .Values.prometheusURL }}
 {{- include "kubernetes.topology.metricProperties.prometheus.namespace" . }}
-{{- else }}
+{{- else if .Values.metrics.enabled }}
 {{- include "kubernetes.topology.metricProperties.k8sMetrics.namespace" . }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -9,6 +9,10 @@ clusterName: kubernetes
 prometheusURL: ""
 # prometheusLabels to inject: "label1=key1,label2=key2,label3=~key3"
 prometheusLabels: ""
+
+metrics:
+  enabled: true
+
 topology:
   name: cluster
   schedule: "@every 5m"


### PR DESCRIPTION
@moshloop Using `.enabled` to keep things consistent

Fixes: https://github.com/flanksource/mission-control-registry/issues/181