### PR TITLE
chore: correclty link helm resources in flux chart

### DIFF
--- a/charts/flux/Chart.yaml
+++ b/charts/flux/Chart.yaml
@@ -3,7 +3,7 @@ name: mission-control-flux
 description: A Helm chart for the Flux bundle for Flanksource Mission Control
 icon: https://github.com/flanksource/docs/blob/main/docs/images/flanksource-icon.png?raw=true
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.0.0"
 maintainers:
   - name: Flanksource

--- a/charts/flux/templates/flux.yaml
+++ b/charts/flux/templates/flux.yaml
@@ -31,7 +31,7 @@ spec:
                     'namespace': r.config.metadata.namespace,
                     'status': r.status,
                     'status_reason': r.description,
-                    'selectors': [{'labelSelector': 'app.kubernetes.io/instance='+r.name}],
+                    'selectors': [{'labelSelector': 'helm.toolkit.fluxcd.io/name='+r.name + ',helm.toolkit.fluxcd.io/namespace=r.config.metadata.namespace}],
                     'configs': [{'name': r.name, 'namespace': r.config.metadata.namespace, 'type': 'Kubernetes::HelmRelease'}],
                     'properties': [
                       {'name': 'Message', 'text': r.config.status.conditions[0].message},


### PR DESCRIPTION
Fixes: https://github.com/flanksource/mission-control-registry/issues/194