### PR TITLE
remove default groupBy from kubernetes cluster

### DIFF
--- a/charts/kubernetes/templates/topology.yaml
+++ b/charts/kubernetes/templates/topology.yaml
@@ -22,10 +22,8 @@ metadata:
     cluster: {{.Values.clusterName}}
     {{- include "kubernetes.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.topology.groupBy }}
   groupBy:
     {{- toYaml .Values.topology.groupBy | nindent 4 }}
-  {{- end }}
   type: Kubernetes::Cluster
   icon: "{{ .Values.topology.icon }}"
   schedule: "{{ .Values.topology.schedule }}"

--- a/charts/kubernetes/templates/topology.yaml
+++ b/charts/kubernetes/templates/topology.yaml
@@ -22,11 +22,10 @@ metadata:
     cluster: {{.Values.clusterName}}
     {{- include "kubernetes.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.topology.groupBy }}
   groupBy:
-    tag: cluster
-    selector:
-      types:
-        - Kubernetes::Cluster
+    {{- toYaml .Values.topology.groupBy | nindent 4 }}
+  {{- end }}
   type: Kubernetes::Cluster
   icon: "{{ .Values.topology.icon }}"
   schedule: "{{ .Values.topology.schedule }}"

--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -73,6 +73,9 @@ topology:
   name: cluster
   schedule: "@every 5m"
   icon: kubernetes
+  groupBy:
+    tag: ''
+    selector: {}
 
 scraper:
   name: kubernetes


### PR DESCRIPTION
The kubernetes topology uses kubernetes lookup. I don't think group by makes sense since the look up for all clusters will be done using the same kubeconfig.

Once we move to catalog lookup, we can bring back the group by.