### PR TITLE
fix: canary status change exclusion

### DIFF
--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -167,7 +167,7 @@ scraper:
     changes:
       exclude:
         - 'details.source.component == "canary-checker" && (change_type == "Failed" || change_type == "Pass")'
-        - 'change_type == "diff" && config_class == "Canary" && summary.startsWith("status.")'
+        - 'change_type == "diff" && config_type == "MissionControl::Canary" && summary.startsWith("status.")'
         - 'config_type == "Kubernetes::Node" && summary == "status.images"'
         - 'has(details.source) && details.source.component == "kustomize-controller" && details.reason == "ReconciliationSucceeded"'
         - 'config_type.startsWith("Kubernetes::") && summary == "metadata.annotations.endpoints.kubernetes.io/last-change-trigger-time"'


### PR DESCRIPTION
The change exclusion variable receives a change result var which doesn't have `config_class`


```go
// +kubebuilder:object:generate=false
type ChangeResult struct {
	ExternalID       string                 `json:"external_id"`
	ConfigType       string                 `json:"config_type"`
	ExternalChangeID string                 `json:"external_change_id"`
	Action           ChangeAction           `json:"action"`
	ChangeType       string                 `json:"change_type"`
	Patches          string                 `json:"patches"`
	Summary          string                 `json:"summary"`
	Severity         string                 `json:"severity"`
	Source           string                 `json:"source"`
	CreatedBy        *string                `json:"created_by"`
	CreatedAt        *time.Time             `json:"created_at"`
	Details          map[string]interface{} `json:"details"`
	Diff             *string                `json:"diff,omitempty"`

	ConfigID string `json:"configID,omitempty"`

	// UpdateExisting indicates whether to update an existing change
	UpdateExisting bool `json:"update_existing"`
}
```