### PR TITLE
chore: only add job history status reason if unhealthy

### DIFF
--- a/charts/mission-control/templates/mission-control.yaml
+++ b/charts/mission-control/templates/mission-control.yaml
@@ -503,7 +503,7 @@ spec:
                   'type': 'JobHistory',
                   'status': r.status,
                   'health': r.status == 'SUCCESS' ? 'healthy': 'unhealthy',
-                  'status_reason': r.details.toJSON(),
+                  'status_reason': if r.status != 'SUCCESS' ? r.details.toJSON() : '',
                   'health': r.error_count == 0 ? 'healthy': (r.success_count == 0 ? 'unhealthy' : 'warning'),
                   'properties': [
                     {'name': 'success_count', 'value': r.success_count, 'headline': true},


### PR DESCRIPTION
Successful jobs have `{}` as status reason
![image](https://github.com/user-attachments/assets/37e820c1-f9a8-4e37-948b-185bdfcd7ec4)
