### PR TITLE
fix(playbooks-kubernetes): fix templating for runsOn

### DIFF
--- a/charts/playbooks-kubernetes/templates/kubectl-logs.yaml
+++ b/charts/playbooks-kubernetes/templates/kubectl-logs.yaml
@@ -6,10 +6,10 @@ metadata:
   name: kubernetes-logs
 spec:
   runsOn:
-    -  $[[` "$[[- if .agent ]]$[[.agent.id]]$[[ else ]]local$[[ end ]]" `]]
+    -  {{` "{{- if .agent }}{{.agent.id}}{{else}}local{{end}}" `}}
   actions:
-   - name: Kubectl Logs
-     exec:
+  - name: Kubectl Logs
+    exec:
       script: |
         # gotemplate: left-delim=$[[ right-delim=]]
 


### PR DESCRIPTION
Its showing a complete diff of the file due to the removal of ^M chars everywhere

![image](https://github.com/user-attachments/assets/6b060c83-a1c9-4f6e-9359-66d9fc037296)

