### PR TITLE
fix(helm): connection key repetition

### DIFF
--- a/charts/helm/templates/_helpers.tpl
+++ b/charts/helm/templates/_helpers.tpl
@@ -2,6 +2,7 @@
 {{- omit .Values.git "url" "base" "branch" | toYaml}}
 url: $(.git.git.url | strings.ReplaceAll "ssh://git@" "https://")
 base: "$(.git.git.branch)"
+connection: {{.Values.git.connection}}
 {{- end}}
 
 {{/*

--- a/charts/helm/templates/_helpers.tpl
+++ b/charts/helm/templates/_helpers.tpl
@@ -2,7 +2,6 @@
 {{- omit .Values.git "url" "base" "branch" | toYaml}}
 url: $(.git.git.url | strings.ReplaceAll "ssh://git@" "https://")
 base: "$(.git.git.branch)"
-connection: {{.Values.git.connection}}
 {{- end}}
 
 {{/*

--- a/charts/helm/templates/playbook.yaml
+++ b/charts/helm/templates/playbook.yaml
@@ -32,8 +32,7 @@ spec:
     - name: Create Pull Request
       gitops:
         repo:
-          {{ include "git-origin" . | nindent 10}}
-          connection: {{.Values.git.connection}}
+          {{- include "git-origin" . | nindent 10}}
           branch: "install-chart-$(.params.chart.name)-$(random.Alpha 8)"
         commit:
           author: '$(.user.name)'


### PR DESCRIPTION
```
Warning  InstallFailed        55s (x14 over 10m)  helm-controller  Helm install failed for release mission-control/mission-control-helm with chart mission-control-helm@0.1.4-beta.1:
 error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 45: mapping key "connection" already defined at line 41
  ```