### PR TITLE
fix: permissions for recommender notification

### DIFF
--- a/charts/playbooks-ai/templates/notification.yaml
+++ b/charts/playbooks-ai/templates/notification.yaml
@@ -54,9 +54,23 @@ spec:
 apiVersion: mission-control.flanksource.com/v1
 kind: Permission
 metadata:
-  name: allow-notify-recommender-config-component-read
+  name: allow-notify-recommender-connection-read
 spec:
-  description: allow notification "notify-recommender-playbook" to read configs & components
+  description: allow notification "notify-recommender-playbook" to read notification connection
+  subject:
+    notification: "{{.Release.Namespace}}/notify-recommender-playbook"
+  actions:
+    - read
+  object:
+    connections:
+      - name: "{{.Values.slack.connection}}"
+---
+apiVersion: mission-control.flanksource.com/v1
+kind: Permission
+metadata:
+  name: allow-notify-recommender-config-read
+spec:
+  description: allow notification "notify-recommender-playbook" to read configs
   subject:
     notification: "{{.Release.Namespace}}/notify-recommender-playbook"
   actions:
@@ -64,6 +78,18 @@ spec:
   object:
     configs:
       - name: "*"
+---
+apiVersion: mission-control.flanksource.com/v1
+kind: Permission
+metadata:
+  name: allow-notify-recommender-component-read
+spec:
+  description: allow notification "notify-recommender-playbook" to read components
+  subject:
+    notification: "{{.Release.Namespace}}/notify-recommender-playbook"
+  actions:
+    - read
+  object:
     components:
       - name: "*"    
 {{- end }}


### PR DESCRIPTION
* must have read access to the slack connection
* must have separate permission for config read & component read. else that's considered as AND query. So the permision only passes if both component & config is supplied.