### PR TITLE
feat: permissions for recommender notification & playbook

### DIFF
--- a/charts/playbooks-ai/README.md
+++ b/charts/playbooks-ai/README.md
@@ -18,7 +18,7 @@ Flanksource Mission Control Playbooks that uses AI action
 | diagnose.playbooksRecommender.notification.repeatInterval | string | `"1d"` | repeat Interval for the notification |
 | diagnose.playbooksRecommender.notification.waitFor | string | `"5m"` | waitFor duration for the notification |
 | diagnose.playbooksRecommender.notification.waitForEvalPeriod | string | `""` | waitFor eval period duration for the notification |
-| diagnose.playbooksRecommender.playbooks | list | `[{"if":"config.status == 'CrashLoopBackOff'","name":"kubernetes-logs","namespace":"{{.Release.Namespace}}","params":{"lines":"5000","since":"2h"}}]` | List of playbooks that provide additional context to the LLM. |
+| diagnose.playbooksRecommender.playbooks | list | `[{"if":"config.status == 'CrashLoopBackOff'","name":"kubernetes-logs","namespace":"{{.Release.Namespace}}","params":{"lines":"500","since":"2h"}}]` | List of playbooks that provide additional context to the LLM. |
 | diagnose.playbooksRecommender.selector | list | `[{"search":"category!=AI"}]` | selector selects the playbooks to recommend |
 | diagnose.playbooksRecommender.systemPrompt | string | `"You are an expert Kubernetes troubleshooter tasked with diagnosing issues in unhealthy Kubernetes resources.\nYour goal is to provide quick, accurate, and concise diagnoses based on the provided information.\n\nInstructions:\n1. Examine the provided configuration thoroughly.\n2. Consider any additional related resources that might be relevant (e.g., pods, replica sets, namespaces).\n3. Analyze potential issues based on the information available.\n4. Formulate a diagnosis of why the resource is unhealthy.\n5. Report your findings in a single, concise sentence.\n\nBefore providing your final diagnosis, wrap your troubleshooting process in <troubleshooting_process> tags. This will ensure a thorough examination of the issue. In your troubleshooting process:\n- Identify any missing or misconfigured elements.\n- Consider potential conflicts with related resources.\n- Evaluate common issues associated with this type of resource.\n- Synthesize the findings into a diagnosis.\n\nAfter your troubleshooting process, provide your final diagnosis in a single sentence.\n\nRemember to prioritize accuracy in your analysis and diagnosis.\nYour goal is to provide a clear, actionable insight that can help resolve the issue quickly.\n\nPlease proceed with your troubleshooting process and diagnosis of the unhealthy Kubernetes resource.\n"` | Optional system prompt for the LLM. If not provided, a default prompt will be used. |
 | diagnose.selector | list | `[{"name":"*"}]` | selector the configs for the playbook resource |
@@ -27,6 +27,7 @@ Flanksource Mission Control Playbooks that uses AI action
 | diagnose.timeframe.changes | string | `"24h"` | Duration to look back at configs changes. |
 | diagnose.timeframe.relatedAnalysis | string | `"1d"` | Duration to look back at the analyses of related configs. |
 | diagnose.timeframe.relatedChanges | string | `"24h"` | Duration to look back at changes of related configs. |
+| global.artifact_connection | string | `""` | Artifact connection to setup the permission |
 | global.llm_connection | string | `""` | LLM connection: one of ollama, openai or anthropic |
 | slack.connection | string | `""` | connection string for slack |
 

--- a/charts/playbooks-ai/templates/_helpers.tpl
+++ b/charts/playbooks-ai/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{/*
+Parse connection string into namespace and name components
+Usage: {{ include "parse-connection" .Values.slack.connection }}
+*/}}
+{{- define "parse-connection" -}}
+{{- $parts := regexSplit "connection://" . -1 }}
+{{- if eq (len $parts) 2 }}
+{{- $nameParts := regexSplit "/" (index $parts 1) -1 }}
+{{- if eq (len $nameParts) 2 }}
+name: {{ index $nameParts 1 }}
+namespace: {{ index $nameParts 0 }}
+{{- end }}
+{{- end }}
+{{- end }} 

--- a/charts/playbooks-ai/templates/notification.yaml
+++ b/charts/playbooks-ai/templates/notification.yaml
@@ -50,46 +50,24 @@ spec:
     playbooks:
       - name: recommend-playbook
         namespace: {{.Release.Namespace}}
----
-apiVersion: mission-control.flanksource.com/v1
-kind: Permission
-metadata:
-  name: allow-notify-recommender-connection-read
-spec:
-  description: allow notification "notify-recommender-playbook" to read notification connection
-  subject:
-    notification: "{{.Release.Namespace}}/notify-recommender-playbook"
-  actions:
-    - read
-  object:
-    connections:
-      - name: "{{.Values.slack.connection}}"
----
-apiVersion: mission-control.flanksource.com/v1
-kind: Permission
-metadata:
-  name: allow-notify-recommender-config-read
-spec:
-  description: allow notification "notify-recommender-playbook" to read configs
-  subject:
-    notification: "{{.Release.Namespace}}/notify-recommender-playbook"
-  actions:
-    - read
-  object:
     configs:
       - name: "*"
 ---
 apiVersion: mission-control.flanksource.com/v1
 kind: Permission
 metadata:
-  name: allow-notify-recommender-component-read
+  name: allow-notify-recommender-connection-read
 spec:
-  description: allow notification "notify-recommender-playbook" to read components
+  description: allow notification "notify-recommender-playbook" to read slack connection
   subject:
     notification: "{{.Release.Namespace}}/notify-recommender-playbook"
   actions:
     - read
   object:
-    components:
-      - name: "*"    
+    connections:
+      {{- with include "parse-connection" .Values.slack.connection }}
+      {{- $connection := . | fromYaml }}
+      - name: {{ $connection.name | quote }}
+        namespace: {{ $connection.namespace | quote }}
+      {{- end }}
 {{- end }}

--- a/charts/playbooks-ai/templates/recommend-playbooks.yaml
+++ b/charts/playbooks-ai/templates/recommend-playbooks.yaml
@@ -56,4 +56,49 @@ spec:
         connection: '{{.Values.slack.connection}}'
         title: Recommended playbooks
         message: '$(getLastAction.result.recommendedPlaybooks)'
+---
+apiVersion: mission-control.flanksource.com/v1
+kind: Permission
+metadata:
+  name: allow-recommender-playbook-connection-read
+spec:
+  description: allow playbook "recommend-playbook" to read slack & llm connection
+  subject:
+    playbook: "{{.Release.Namespace}}/recommend-playbook"
+  actions:
+    - read
+  object:
+    connections:
+      {{- with include "parse-connection" .Values.slack.connection }}
+      {{- $connection := . | fromYaml }}
+      - name: {{ $connection.name | quote }}
+        namespace: {{ $connection.namespace | quote }}
+      {{- end }}
+      {{- with include "parse-connection" .Values.global.llm_connection }}
+      {{- $connection := . | fromYaml }}
+      - name: {{ $connection.name | quote }}
+        namespace: {{ $connection.namespace | quote }}
+      {{- end }}
+      {{- with include "parse-connection" .Values.global.artifact_connection }}
+      {{- $connection := . | fromYaml }}
+      - name: {{ $connection.name | quote }}
+        namespace: {{ $connection.namespace | quote }}
+      {{- end }}
+---
+apiVersion: mission-control.flanksource.com/v1
+kind: Permission
+metadata:
+  name: allow-recommender-playbook-kubernetes-logs-playbook
+spec:
+  description: allow playbook "recommend-playbook" to run the kubernetes logs playbook
+  subject:
+    playbook: "{{.Release.Namespace}}/recommend-playbook"
+  actions:
+    - playbook:*
+  object:
+    playbooks:
+      - name: kubernetes-logs
+        namespace: {{.Release.Namespace}}
+    configs:
+      - name: "*"
 {{- end }}

--- a/charts/playbooks-ai/values.schema.json
+++ b/charts/playbooks-ai/values.schema.json
@@ -248,6 +248,13 @@
       "additionalProperties": false,
       "description": "yaml-language-server: $schema=values.schema.json",
       "properties": {
+        "artifact_connection": {
+          "default": "",
+          "description": "Artifact connection to setup the permission",
+          "required": [],
+          "title": "artifact_connection",
+          "type": "string"
+        },
         "llm_connection": {
           "default": "",
           "description": "LLM connection: one of ollama, openai or anthropic",

--- a/charts/playbooks-ai/values.yaml
+++ b/charts/playbooks-ai/values.yaml
@@ -8,6 +8,13 @@ global:
   # -- LLM connection: one of ollama, openai or anthropic
   llm_connection: ""
 
+  # @schema
+  # type: string
+  # required: false
+  # @schema
+  # -- Artifact connection to setup the permission
+  artifact_connection: ""
+
 slack:
   # @schema
   # type: string


### PR DESCRIPTION
Notification needs
- `playbook:run` on the recommender playbook + any config
- `read` on slack connection (fallback)

Playbook needs
- `read` on connections
  - slack
  - artifacts
  - LLM
- `playbook:run` on kubernetes-logs playbook