### PR TITLE
chore(mission-control): use only last 7 days job history for its topology

### DIFF
--- a/charts/mission-control/templates/mission-control.yaml
+++ b/charts/mission-control/templates/mission-control.yaml
@@ -610,7 +610,7 @@ spec:
                 FROM job_history
                 WHERE status NOT IN ('RUNNING', 'SKIPPED', 'STALE')
               )
-              SELECT * from ordered_history where rn = 1 and resource_id = '';
+              SELECT * FROM ordered_history WHERE rn = 1 AND resource_id = '' AND created_at >= NOW() - INTERVAL '7 days'
             display:
               expr: |
                 results.rows.map(r, {


### PR DESCRIPTION
We retain last 30 days but I think only last 7 days is relevant in topology