### PR TITLE
Add CPU and memory usage columns to cluster overview

### DIFF
--- a/charts/kubernetes-view/templates/cluster-overview.yaml
+++ b/charts/kubernetes-view/templates/cluster-overview.yaml
@@ -139,7 +139,6 @@ spec:
     cpu_usage_by_namespace:
       columns:
         namespace: string
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
@@ -152,7 +151,6 @@ spec:
     memory_usage_by_namespace:
       columns:
         namespace: string
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
@@ -165,7 +163,6 @@ spec:
     cpu_limit_by_namespace:
       columns:
         namespace: string
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
@@ -178,7 +175,6 @@ spec:
     memory_limit_by_namespace:
       columns:
         namespace: string
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
@@ -191,35 +187,26 @@ spec:
     pods_node_distribution:
       columns:
         node: string
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           count(kube_pod_info) by (node)
     total_cpu:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           sum(machine_cpu_cores{})
     cpu_usage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           sum(rate(node_cpu_seconds_total{mode!~"idle|iowait|steal", job="node-exporter"}[5m]))
     total_memory:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           sum(kube_node_status_allocatable{resource="memory"}) / 1024 / 1024 / 1024
     memory_usage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
@@ -227,7 +214,6 @@ spec:
     resource_count_by_type:
       columns:
         resource_type: string
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
@@ -242,43 +228,31 @@ spec:
           (label_replace(count(kube_ingress_info), "resource_type", "Ingresses", "", "")) or
           (label_replace(count(kube_cronjob_info), "resource_type", "CronJobs", "", ""))
     memory_real_percentage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           sum(node_memory_MemTotal_bytes{job="node-exporter"} - node_memory_MemAvailable_bytes{job="node-exporter"}) / sum(node_memory_MemTotal_bytes{job="node-exporter"}) * 100
     memory_request_percentage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           sum(kube_pod_container_resource_requests{resource="memory"}) / sum(machine_memory_bytes{}) * 100
     memory_limit_percentage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           sum(kube_pod_container_resource_limits{resource="memory"}) / sum(machine_memory_bytes{}) * 100
     cpu_real_percentage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           avg(sum by (instance, cpu) (rate(node_cpu_seconds_total{mode!~"idle|iowait|steal", job="node-exporter"}[5m]))) * 100
     cpu_request_percentage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |
           sum(kube_pod_container_resource_requests{resource="cpu"}) / sum(machine_cpu_cores{}) * 100
     cpu_limit_percentage:
-      columns:
-        value: decimal
       prometheus:
         connection: {{ .Values.global.prometheus.connection }}
         query: |


### PR DESCRIPTION
## Summary
Display per-namespace CPU and memory metrics in the cluster overview table with color-coded gauges