### PR TITLE
fix: Deployments view should now require prometheus connection

### DIFF
--- a/charts/kubernetes-view/templates/deployments.yaml
+++ b/charts/kubernetes-view/templates/deployments.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.views.enabled .Values.views.deployments.enabled }}
+{{- if and .Values.views.enabled .Values.views.deployments.enabled .Values.global.prometheus.connection }}
 apiVersion: mission-control.flanksource.com/v1
 kind: View
 metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Deployments view now requires Prometheus connection to be configured in order to display. Users must ensure Prometheus connectivity is properly set up for this view to render in the Kubernetes manifest.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->