### PR TITLE
fix: nodes view

### DIFF
--- a/charts/kubernetes-view/templates/node.yaml
+++ b/charts/kubernetes-view/templates/node.yaml
@@ -167,12 +167,6 @@ spec:
       card:
         position: body
       description: Running pods count
-      url:
-        view:
-          filter:
-            viewvar__cluster: row.cluster
-          name: >
-            'pods'
     - name: allocatable_cpu
       type: number
       unit: millicore


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed clickable pods links from the Pods Node Distribution panel. The pods view is no longer accessible through this panel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->