### PR TITLE
fix: Pods view - add node filter

### DIFF
--- a/charts/kubernetes-view/templates/pods.yaml
+++ b/charts/kubernetes-view/templates/pods.yaml
@@ -162,6 +162,8 @@ spec:
     - name: node
       type: string
       hidden: true
+      filter:
+        type: multiselect
       card:
         position: body
   merge: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiselect filtering to the node column, enabling users to filter and display pods from multiple nodes simultaneously in the Kubernetes view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->