### PR TITLE
fix: improve PromQL query reliability

### DIFF
--- a/charts/kubernetes-view/templates/cluster-overview.yaml
+++ b/charts/kubernetes-view/templates/cluster-overview.yaml
@@ -251,7 +251,7 @@ spec:
           sum by (namespace) (
             irate(container_cpu_usage_seconds_total{
               container!="POD",
-              image!=""
+              container!=""
             }[5m])
           ) * 1000
     memory_usage_by_namespace:
@@ -264,7 +264,7 @@ spec:
           sum by (namespace) (
             container_memory_working_set_bytes{
               container!="POD",
-              image!=""
+              container!=""
             }
           )
     cpu_limit_by_namespace:

--- a/charts/kubernetes-view/templates/namespace.yaml
+++ b/charts/kubernetes-view/templates/namespace.yaml
@@ -175,7 +175,7 @@ spec:
           sum by (namespace, pod) (
             container_memory_working_set_bytes{
               container!="POD", # Skip The pause/infra container
-              image!="" # Skip dead containers
+              container!="" # Skip dead containers
             }
           )
     cpu: # cpu_per_pod
@@ -189,8 +189,8 @@ spec:
           sum by (namespace, pod) (
             irate(container_cpu_usage_seconds_total{
               container!="POD", # Skip The pause/infra container
-              image!="" # Skip dead containers
-            }[30s])
+              container!="" # Skip dead containers
+            }[5m])
           ) * 1000
     pod: # all pods in the namespace
       configs:
@@ -208,7 +208,7 @@ spec:
             irate(container_cpu_usage_seconds_total{
               namespace=~"$(.var.namespace)",
               container!="POD",
-              image!=""
+              container!=""
             }[5m])
           ) * 1000
     namespace_memory_usage:
@@ -221,7 +221,7 @@ spec:
             container_memory_working_set_bytes{
               namespace=~"$(.var.namespace)",
               container!="POD",
-              image!=""
+              container!=""
             }
           ) or vector(0)
     namespace_memory_limit:

--- a/charts/kubernetes-view/templates/pod.yaml
+++ b/charts/kubernetes-view/templates/pod.yaml
@@ -107,7 +107,7 @@ spec:
             container_memory_working_set_bytes{
               pod="$(.var.pod_name)",
               container!="POD", # Skip The pause/infra container
-              image!="" # Skip dead containers
+              container!="" # Skip dead containers
             }
           )
     cpu_usage:
@@ -122,8 +122,8 @@ spec:
             irate(container_cpu_usage_seconds_total{
               pod="$(.var.pod_name)",
               container!="POD",
-              image!=""
-            }[30s])
+              container!=""
+            }[5m])
           ) * 1000
     pod:
       configs:

--- a/charts/kubernetes-view/templates/pods.yaml
+++ b/charts/kubernetes-view/templates/pods.yaml
@@ -207,7 +207,7 @@ spec:
           sum by (namespace, pod) (
             container_memory_working_set_bytes{
               container!="POD", # Skip The pause/infra container
-              image!="" # Skip dead containers
+              container!="" # Skip dead containers
             }
           )
     cpu:
@@ -221,8 +221,8 @@ spec:
           sum by (namespace, pod) (
             irate(container_cpu_usage_seconds_total{
               container!="POD", # Skip The pause/infra container
-              image!="" # Skip dead containers
-            }[30s])
+              container!="" # Skip dead containers
+            }[5m])
           ) * 1000
     pod:
       configs:

--- a/charts/mission-control/templates/view.yaml
+++ b/charts/mission-control/templates/view.yaml
@@ -88,7 +88,7 @@ spec:
           sum by (namespace, pod) (
             container_memory_working_set_bytes{
               container!="POD", # Skip The pause/infra container
-              image!="" # Skip dead containers
+              container!="" # Skip dead containers
             }
           )
     cpu:
@@ -102,8 +102,8 @@ spec:
           sum by (namespace, pod) (
             irate(container_cpu_usage_seconds_total{
               container!="POD", # Skip The pause/infra container
-              image!="" # Skip dead containers
-            }[30s])
+              container!="" # Skip dead containers
+            }[5m])
           ) * 1000
     pod:
       configs:


### PR DESCRIPTION
- Use 5m window for irate() instead of 30s for more data points
- Use container!="" instead of image!="" which may be empty in newer cAdvisor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container resource metrics accuracy by refining metric collection filters across Kubernetes monitoring dashboards.
  * Extended CPU utilization calculation time windows from 30 seconds to 5 minutes, providing more stable and reliable trend analysis for resource usage patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->