### PR TITLE
fix: agents:all in kubernetes views

### DIFF
--- a/charts/kubernetes-view/templates/ingress.yaml
+++ b/charts/kubernetes-view/templates/ingress.yaml
@@ -29,6 +29,7 @@ spec:
       configs:
         tagSelector: "cluster=$(.var.cluster)"
         search: "@order=name"
+        agent: "all"
         types:
           - Kubernetes::Ingress
   columns:

--- a/charts/kubernetes-view/templates/namespace.yaml
+++ b/charts/kubernetes-view/templates/namespace.yaml
@@ -33,6 +33,7 @@ spec:
         - cluster
       valueFrom:
         config:
+          agent: "all"
           tagSelector: "cluster=$(.var.cluster)"
           types:
             - Kubernetes::Namespace

--- a/charts/kubernetes-view/templates/pod.yaml
+++ b/charts/kubernetes-view/templates/pod.yaml
@@ -127,6 +127,7 @@ spec:
           ) * 1000
     pod:
       configs:
+        agent: "all"
         tagSelector: "cluster=$(.var.cluster)"
         name: $(.var.pod_name)
         types:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated query configurations for Ingress, Namespace, and Pod resources to implement consistent agent filtering patterns. These changes standardize agent-based filtering across all resource types in the Kubernetes view, ensuring uniform query behavior and improving configuration consistency throughout the interface for more reliable resource management operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->