### PR TITLE
fix: Additional property prometheusURL is not allowed

### DIFF
--- a/charts/mission-control/values.schema.json
+++ b/charts/mission-control/values.schema.json
@@ -40,6 +40,11 @@
       "title": "playbooks",
       "type": "boolean"
     },
+    "prometheusURL": {
+      "default": "",
+      "title": "prometheusURL",
+      "type": "string"
+    },
     "pushLocation": {
       "additionalProperties": false,
       "properties": {

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -4,6 +4,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 # @schema
+# required: false
+# type: string
+# @schema
+prometheusURL: ""
+
+# @schema
 # type: object
 # additionalProperties: true
 # required: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a Prometheus URL parameter, allowing users to specify custom Prometheus service endpoints for monitoring and metrics collection integration within their Mission Control deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->