### PR TITLE
fix(mssql): use job id for uniqueness and make test-data idempotent

### DIFF
--- a/charts/mssql/conf/agent-jobs.sql
+++ b/charts/mssql/conf/agent-jobs.sql
@@ -111,6 +111,3 @@ LEFT JOIN JobStepsAgg jst ON js.job_id = jst.job_id;
 
 -- Clean up temp table
 DROP TABLE #JobSteps;
-
-
-

--- a/charts/mssql/templates/scraper.yaml
+++ b/charts/mssql/templates/scraper.yaml
@@ -71,7 +71,7 @@ spec:
 {{- if .Values.scrape.jobs }}
     - type: MSSQL::AgentJob
       {{ include "mssql.connection" . | indent 6 | trim }}
-      id: $.name
+      id: $.id
       name: $.name
       transform:
         expr: |
@@ -107,10 +107,10 @@ spec:
       transform:
         expr: |
           [{
-            'id': config.job_name,
+            'id': config.job_id,
             'changes': [{
               'config_type': 'MSSQL::AgentJob',
-              'external_id': config.job_name,
+              'external_id': config.job_id,
               'scraper_id': 'all',
               'external_change_id': config.external_change_id,
               'created_at': config.created_at,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * MSSQL Agent Jobs now use job ID instead of job name for identification and external ID mapping, improving tracking reliability.

* **Tests**
  * Enhanced test data setup with automated database initialization, sample tables with seed data, database logins, and a configured SQL Server Agent job with scheduling.

* **Chores**
  * Cleaned up formatting in configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->