### PR TITLE
chore(dashboard): change sort order to updated and increase limit

### DIFF
--- a/charts/mission-control/templates/views/dashboard/unhealthy-configs.yaml
+++ b/charts/mission-control/templates/views/dashboard/unhealthy-configs.yaml
@@ -14,18 +14,8 @@ spec:
     sidebar: true
     {{- end }}
     table:
-      size: 10
-      sort: -created
+      sort: -updated
   panels:
-    - name: By Health
-      description: Configs grouped by health status
-      type: piechart
-      piechart:
-        showLabels: true
-        colors:
-          unhealthy: "#F04E6E"
-          warning: "#F4B23C"
-      query: SELECT COUNT(*) AS count, health FROM configs GROUP BY health
     - name: By Type
       description: Unhealthy configs grouped by type
       type: piechart
@@ -67,7 +57,7 @@ spec:
       configs:
         agent: "all"
         health: "unhealthy,warning"
-        limit: 10
+        limit: 200
   mapping:
     updated: row.updated_at
     created: row.created_at


### PR DESCRIPTION
Updated sorting and limit parameters for unhealthy configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed the "By Health" panel from the dashboard view.
  * Changed table sorting to display configurations by their last updated timestamp instead of creation date.
  * Increased the maximum number of configurations displayed in the Configs section from 10 to 200 items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->