### PR TITLE
fix: Ingress don't default to card view

### DIFF
--- a/charts/kubernetes-view/templates/ingress.yaml
+++ b/charts/kubernetes-view/templates/ingress.yaml
@@ -15,7 +15,6 @@ spec:
     {{- end }}
     card:
       columns: 2
-      default: true
   templating:
     - key: cluster
       label: Cluster


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a default configuration setting from the Kubernetes ingress template.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->