### PR TITLE
feat(mssql): Enhance long-running transaction detection and killing

### DIFF
--- a/charts/mssql/conf/kill-long-running-transactions.sql
+++ b/charts/mssql/conf/kill-long-running-transactions.sql
@@ -1,31 +1,89 @@
-DECLARE @threshold_seconds INT = $(.params.threshold);
+DECLARE @threshold_seconds INT = CAST($(.params.threshold) AS INT);
 DECLARE @session_id INT;
-DECLARE @killed_count INT = 0;
 
-DECLARE session_cursor CURSOR FOR
-SELECT r.session_id
+-- Snapshot of sessions about to be killed, returned at the end as the audit trail.
+DECLARE @victims TABLE (
+    kind                VARCHAR(20),
+    session_id          INT,
+    start_time          DATETIME,
+    duration_seconds    INT,
+    status              NVARCHAR(60),
+    login_name          NVARCHAR(256),
+    host_name           NVARCHAR(256),
+    program_name        NVARCHAR(256),
+    database_name       NVARCHAR(256),
+    query_text          NVARCHAR(MAX),
+    kill_status         NVARCHAR(256)
+);
+
+INSERT INTO @victims (kind, session_id, start_time, duration_seconds, status, login_name, host_name, program_name, database_name, query_text, kill_status)
+SELECT
+    'request',
+    r.session_id,
+    r.start_time,
+    DATEDIFF(SECOND, r.start_time, GETDATE()),
+    r.status,
+    s.login_name,
+    s.host_name,
+    s.program_name,
+    DB_NAME(r.database_id),
+    t.text,
+    NULL
 FROM sys.dm_exec_requests r
 JOIN sys.dm_exec_sessions s ON r.session_id = s.session_id
+CROSS APPLY sys.dm_exec_sql_text(r.sql_handle) t
 WHERE r.session_id != @@SPID
   AND s.is_user_process = 1
+  AND r.status <> 'rollback'
   AND DATEDIFF(SECOND, r.start_time, GETDATE()) > @threshold_seconds;
 
-OPEN session_cursor;
-FETCH NEXT FROM session_cursor INTO @session_id;
+INSERT INTO @victims (kind, session_id, start_time, duration_seconds, status, login_name, host_name, program_name, database_name, query_text, kill_status)
+SELECT
+    'idle_open_tx',
+    s.session_id,
+    at.transaction_begin_time,
+    DATEDIFF(SECOND, at.transaction_begin_time, GETDATE()),
+    s.status,
+    s.login_name,
+    s.host_name,
+    s.program_name,
+    DB_NAME(s.database_id),
+    lq.text,
+    NULL
+FROM sys.dm_tran_session_transactions st
+JOIN sys.dm_tran_active_transactions at ON st.transaction_id = at.transaction_id
+JOIN sys.dm_exec_sessions s              ON st.session_id = s.session_id
+LEFT JOIN sys.dm_exec_connections c      ON c.session_id = s.session_id
+OUTER APPLY sys.dm_exec_sql_text(c.most_recent_sql_handle) lq
+WHERE s.is_user_process = 1
+  AND s.session_id != @@SPID
+  AND NOT EXISTS (
+        SELECT 1 FROM sys.dm_exec_requests r
+        WHERE r.session_id = s.session_id AND r.status = 'rollback'
+  )
+  AND DATEDIFF(SECOND, at.transaction_begin_time, GETDATE()) > @threshold_seconds;
+
+DECLARE victim_cursor CURSOR LOCAL FAST_FORWARD FOR
+    SELECT session_id FROM @victims;
+
+OPEN victim_cursor;
+FETCH NEXT FROM victim_cursor INTO @session_id;
 
 WHILE @@FETCH_STATUS = 0
 BEGIN
     BEGIN TRY
-        KILL @session_id;
-        SET @killed_count = @killed_count + 1;
+        EXEC ('KILL ' + CAST(@session_id AS VARCHAR(10)));
+        UPDATE @victims SET kill_status = 'killed' WHERE session_id = @session_id;
     END TRY
     BEGIN CATCH
-        PRINT 'Failed to kill session ' + CAST(@session_id AS VARCHAR(10)) + ': ' + ERROR_MESSAGE();
+        UPDATE @victims
+        SET kill_status = 'failed: ' + ERROR_MESSAGE()
+        WHERE session_id = @session_id;
     END CATCH
-    FETCH NEXT FROM session_cursor INTO @session_id;
+    FETCH NEXT FROM victim_cursor INTO @session_id;
 END
 
-CLOSE session_cursor;
-DEALLOCATE session_cursor;
+CLOSE victim_cursor;
+DEALLOCATE victim_cursor;
 
-SELECT @killed_count AS sessions_killed;
+SELECT * FROM @victims ORDER BY duration_seconds DESC;

--- a/charts/mssql/conf/list-long-running-transactions.sql
+++ b/charts/mssql/conf/list-long-running-transactions.sql
@@ -1,19 +1,57 @@
+DECLARE @threshold_seconds INT = CAST($(.params.threshold) AS INT);
+
+-- Active requests running longer than the threshold.
 SELECT
+    'request'                                                AS kind,
     r.session_id,
     r.start_time,
-    DATEDIFF(SECOND, r.start_time, GETDATE()) AS duration_seconds,
+    DATEDIFF(SECOND, r.start_time, GETDATE())                AS duration_seconds,
     r.status,
     r.command,
     r.wait_type,
+    r.wait_resource,
     r.blocking_session_id,
     s.login_name,
     s.host_name,
     s.program_name,
-    DB_NAME(r.database_id) AS database_name,
-    t.text AS query_text
+    DB_NAME(r.database_id)                                   AS database_name,
+    t.text                                                   AS query_text
 FROM sys.dm_exec_requests r
 JOIN sys.dm_exec_sessions s ON r.session_id = s.session_id
 CROSS APPLY sys.dm_exec_sql_text(r.sql_handle) t
 WHERE r.session_id != @@SPID
   AND s.is_user_process = 1
-ORDER BY r.start_time ASC;
+  AND DATEDIFF(SECOND, r.start_time, GETDATE()) > @threshold_seconds
+
+UNION ALL
+
+-- Idle sessions with an open transaction older than the threshold.
+-- These are the classic blocker / deadlock culprits that don't show up in dm_exec_requests.
+SELECT
+    'idle_open_tx'                                           AS kind,
+    s.session_id,
+    at.transaction_begin_time                                AS start_time,
+    DATEDIFF(SECOND, at.transaction_begin_time, GETDATE())   AS duration_seconds,
+    s.status,
+    NULL                                                     AS command,
+    NULL                                                     AS wait_type,
+    NULL                                                     AS wait_resource,
+    NULL                                                     AS blocking_session_id,
+    s.login_name,
+    s.host_name,
+    s.program_name,
+    DB_NAME(s.database_id)                                   AS database_name,
+    lq.text                                                  AS query_text
+FROM sys.dm_tran_session_transactions st
+JOIN sys.dm_tran_active_transactions at ON st.transaction_id = at.transaction_id
+JOIN sys.dm_exec_sessions s              ON st.session_id = s.session_id
+LEFT JOIN sys.dm_exec_connections c      ON c.session_id = s.session_id
+OUTER APPLY sys.dm_exec_sql_text(c.most_recent_sql_handle) lq
+WHERE s.is_user_process = 1
+  AND s.session_id != @@SPID
+  AND NOT EXISTS (
+        SELECT 1 FROM sys.dm_exec_requests r WHERE r.session_id = s.session_id
+  )
+  AND DATEDIFF(SECOND, at.transaction_begin_time, GETDATE()) > @threshold_seconds
+
+ORDER BY duration_seconds DESC;


### PR DESCRIPTION
**What**
- Expand transaction monitoring to detect both active requests and idle sessions with open transactions
- Add comprehensive audit trail capturing session details and kill status for each victim
- Improve query accuracy by filtering out rollback operations and adding wait resource visibility

**Breaking Change**
- Output format changed from simple count to detailed result set with transaction kind, session details, and kill status for each victim