### PR TITLE
fix: invalid kubernetes-logs playbook manifest

### DIFF
--- a/charts/playbooks-kubernetes/templates/kubectl-logs.yaml
+++ b/charts/playbooks-kubernetes/templates/kubectl-logs.yaml
@@ -5,11 +5,11 @@ kind: Playbook
 metadata:
   name: kubernetes-logs
 spec:
+  description: Get logs using stern
   runsOn:
     -  {{` "{{- if .agent }}{{.agent.id}}{{else}}local{{end}}" `}}
   actions:
   - name: stern
-    description: Get logs using stern
     exec:
       {{- include "exec-action-connections" . | nindent 6}}
       script: |


### PR DESCRIPTION
`description` field does not exist per action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced description for the logs retrieval functionality to provide clearer information about its capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->