### PR TITLE
fix(aws): set CloudTrail maxAge to 36h

### DIFF
--- a/charts/aws/templates/scraper.yaml
+++ b/charts/aws/templates/scraper.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   aws:
   - compliance: {{ .Values.compliance }}
+    cloudtrail: {{ .Values.cloudtrail | default dict | toYaml | nindent 6 }}
 
     {{- if .Values.costReporting.enabled }}
     cost_reporting:

--- a/charts/aws/values.schema.json
+++ b/charts/aws/values.schema.json
@@ -36,7 +36,7 @@
           "type": "array"
         },
         "maxAge": {
-          "default": "7d",
+          "default": "36h",
           "description": "Maximum lookback age when querying cloudtrail",
           "required": [],
           "title": "maxAge"

--- a/charts/aws/values.yaml
+++ b/charts/aws/values.yaml
@@ -51,7 +51,7 @@ cloudtrail:
   # @schema
   # description: Maximum lookback age when querying cloudtrail
   # @schema
-  maxAge: 7d
+  maxAge: 36h
   # @schema
   # type: array
   # description: list of events to to exclude


### PR DESCRIPTION
AWS chart values configured CloudTrail `maxAge`, but the scraper template did not render the `cloudtrail` block into the generated `ScrapeConfig`.\n\nSet the default CloudTrail lookback to `36h` and include the CloudTrail settings in the AWS scraper manifest so config-db receives the intended duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudTrail configuration support to the AWS scraping setup, allowing CloudTrail settings to be included in deployment values.
* **Behavior Changes**
  * Updated the default CloudTrail query lookback window from 7 days to 36 hours for faster, more targeted scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->