### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -30,6 +30,9 @@ on:
         default: "latest"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -25,6 +25,9 @@ on:
           - helm
           - mssql
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to all GitHub Actions workflows to resolve the CodeQL "Workflow does not contain permissions" findings. Write operations already use the `FLANKBOT` token, so read-only is sufficient.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Z6eomJ9xZxsotv8voAwFv)_