### PR TITLE
fix(kubernetes-view): add default gauge option in non prometheus

### DIFF
--- a/charts/kubernetes-view/templates/node-non-prometheus.yaml
+++ b/charts/kubernetes-view/templates/node-non-prometheus.yaml
@@ -82,16 +82,19 @@ spec:
       width: "1"
     - name: cpu
       type: gauge
+      gauge: {}
       unit: millicore
       hidden: true
       gauge: {}
     - name: memory
       type: gauge
+      gauge: {}
       unit: bytes
       hidden: true
       gauge: {}
     - name: disk
       type: gauge
+      gauge: {}
       unit: percent
       hidden: true
       gauge: {}

--- a/charts/kubernetes-view/templates/pods-non-prometheus.yaml
+++ b/charts/kubernetes-view/templates/pods-non-prometheus.yaml
@@ -99,11 +99,13 @@ spec:
         type: multiselect
     - name: memory
       type: gauge
+      gauge: {}
       unit: bytes
       hidden: true
       gauge: {}
     - name: cpu
       type: gauge
+      gauge: {}
       unit: millicore
       hidden: true
       gauge: {}


### PR DESCRIPTION
Error: INSTALLATION FAILED: server-side apply failed for object mission-control/nodes mission-control.flanksource.com/v1, Kind=View: View.mission-control.flanksource.com "nodes" is invalid: [spec.columns[6]: Invalid value: "object": gauge config required when type is gauge, not allowed for other types, spec.columns[7]: Invalid value: "object": gauge config required when type is gauge, not allowed for other types, spec.columns[8]: Invalid value: "object": gauge config required when type is gauge, not allowed for other types]
  server-side apply failed for object mission-control/pods mission-control.flanksource.com/v1, Kind=View: View.mission-control.flanksource.com "pods" is invalid: [spec.columns[7]: Invalid value: "object": gauge config required when type is gauge, not allowed for other types, spec.columns[8]: Invalid value: "object": gauge config required when type is gauge, not allowed for other types]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved CPU, memory, and disk metric displays in Kubernetes node and pod views.
  * Added consistent gauge support for relevant resource metrics.
  * Preserved existing metric units and visibility settings for a familiar viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->