### PR TITLE
fix(kubernetes-view): add gauge config to hidden columns

### DIFF
--- a/charts/kubernetes-view/templates/node-non-prometheus.yaml
+++ b/charts/kubernetes-view/templates/node-non-prometheus.yaml
@@ -84,14 +84,17 @@ spec:
       type: gauge
       unit: millicore
       hidden: true
+      gauge: {}
     - name: memory
       type: gauge
       unit: bytes
       hidden: true
+      gauge: {}
     - name: disk
       type: gauge
       unit: percent
       hidden: true
+      gauge: {}
     - name: pods
       type: number
       hidden: true

--- a/charts/kubernetes-view/templates/pods-non-prometheus.yaml
+++ b/charts/kubernetes-view/templates/pods-non-prometheus.yaml
@@ -101,10 +101,12 @@ spec:
       type: gauge
       unit: bytes
       hidden: true
+      gauge: {}
     - name: cpu
       type: gauge
       unit: millicore
       hidden: true
+      gauge: {}
     - name: memory_request
       type: number
       unit: bytes


### PR DESCRIPTION
The non-Prometheus pod and node views define hidden gauge columns without gauge configuration.

The View CRD requires `gauge` configuration whenever `type` is `gauge`, causing chart `0.1.38` installations to fail.

Add empty gauge configurations to these hidden columns so they satisfy CRD validation without changing their display behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU, memory, and disk gauge display behavior in the Kubernetes Nodes view.
  * Improved CPU and memory gauge display behavior in the Kubernetes Pods view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->